### PR TITLE
enable nat-keepalive

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -134,6 +134,8 @@ conn shared
   ike=3des-sha1,3des-sha2,aes-sha1,aes-sha1;modp1024,aes-sha2,aes-sha2;modp1024,aes256-sha2_512
   phase2alg=3des-sha1,3des-sha2,aes-sha1,aes-sha2,aes256-sha2_512
   sha2-truncbug=yes
+  nat-keepalive=yes
+  keep-alive=18
 
 conn l2tp-psk
   auto=add


### PR DESCRIPTION
I think this should help with keeping VPN connected when the client is idle. From [libreswan doc](https://libreswan.org/man/ipsec.conf.5.html):

> nat-keepalive
> whether to send any NAT-T keep-alives. These one byte packets are send to prevent the NAT router from closing its port when there is not enough traffic on the IPsec connection. Acceptable values are: yes (the default) and no.

Also more [here](https://www.cisco.com/en/US/docs/ios-xml/ios/sec_conn_dplane/configuration/15-1mt/sec-ipsec-nat-transp.html#GUID-54C3D921-581F-48B8-9641-5942C19DEA1F)