### PR TITLE
Added possibility for automatic resolve dns hostnames to IPs

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -109,6 +109,12 @@ XAUTH_POOL=${VPN_XAUTH_POOL:-'192.168.43.10-192.168.43.250'}
 DNS_SRV1=${VPN_DNS_SRV1:-'8.8.8.8'}
 DNS_SRV2=${VPN_DNS_SRV2:-'8.8.4.4'}
 
+# If is not IP, try to resolve DNS servers hostnames to ip
+check_ip "$DNS_SRV1" || DNS_SRV1=$(dig +short $DNS_SRV1)
+check_ip "$DNS_SRV2" || DNS_SRV2=$(dig +short $DNS_SRV2)
+check_ip "$DNS_SRV1" || exiterr "Cannot resolve 'VPN_DNS_SRV1' variable content. Please check it if it was correctly defined in your 'env' file."
+check_ip "$DNS_SRV2" || exiterr "Cannot resolve 'VPN_DNS_SRV2' variable content. Please check it if it was correctly defined in your 'env' file."
+
 # Create IPsec (Libreswan) config
 cat > /etc/ipsec.conf <<EOF
 version 2.0


### PR DESCRIPTION
If you are using custom DNS server like Dnsmasq in same docker network it possible now to define DNS server by hostname. Hostname in that case will be resolved to IP and connected user to VPN will get chance to use this DNS server.

Here is example how to use it with docker swarm:
```yaml
version: '3.6'

services:
  runner:
    image: elifa/swarm-proxy #this image is used to start hwdsl2/ipsec-vpn-server in privileged mode on swarm
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
    command: 4500:4500
    environment:
      RUN: -e="VPN_DNS_SRV1=dns" -e="VPN_DNS_SRV2=1.1.1.1" -e "VPN_PASSWORD=${VPN_PASSWORD}" -e "VPN_USER=${VPN_USER}" -e "VPN_IPSEC_PSK=${VPN_IPSEC_PSK}" -p 500:500/udp -p 4500:4500/udp --privileged -v /lib/modules:/lib/modules:ro --name=vpn-server --network=vpn hwdsl2/ipsec-vpn-server
    networks:
      - access
    deploy:
      mode: replicated
      replicas: 1
      endpoint_mode: vip
      placement:
        constraints: [node.role == manager]
      restart_policy:
        condition: on-failure
        delay: 0s
      update_config:
        parallelism: 1
        delay: 30s

  dns:
    image: jiadx/docker-dns-gen
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
    networks:
      access:
    deploy:
      mode: replicated
      replicas: 1
      endpoint_mode: vip
      placement:
        constraints: [node.role == manager]
      restart_policy:
        condition: any
        window: 5s
        delay: 0s
      update_config:
        parallelism: 1
        delay: 0s
        failure_action: rollback
        order: stop-first

networks:
  access:
    driver: overlay
    attachable: true
    name: vpn
    ipam:
      driver: default
      config:
        - subnet: 10.0.4.0/24
```