### PR TITLE
usernames must be quoted.

### DIFF
--- a/vpn.env.example
+++ b/vpn.env.example
@@ -8,8 +8,9 @@ VPN_PASSWORD=your_vpn_password
 # (Optional) Define additional VPN users
 # - Uncomment and replace with your own values
 # - Usernames and passwords must be separated by spaces
-# VPN_ADDL_USERS=additional_username_1 additional_username_2
-# VPN_ADDL_PASSWORDS=additional_password_1 additional_password_2
+# - If there are more than one Username. Usernames/passwords must be quoted.
+# VPN_ADDL_USERS="additional_username_1 additional_username_2"
+# VPN_ADDL_PASSWORDS="additional_password_1 additional_password_2"
 
 # (Optional) Use alternative DNS servers
 # - By default, clients are set to use Google Public DNS


### PR DESCRIPTION
run.sh source **vpn.env** to import variables.
because
```bash
var=values values
```
is not valid.
it has to be quoted like
```bash
var="values values"
```