### PR TITLE
Use git ref for image tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,6 +274,7 @@ jobs:
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             --build-arg VERSION=latest \
             -t "$DOCKER_USER/ipsec-vpn-server:latest" \
+            -t "$DOCKER_USER/ipsec-vpn-server:$GITHUB_REF" \
             --push \
             .
 
@@ -284,6 +285,7 @@ jobs:
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             --build-arg VERSION=latest \
             -t "quay.io/$DOCKER_USER/ipsec-vpn-server:latest" \
+            -t "$DOCKER_USER/ipsec-vpn-server:$GITHUB_REF" \
             --push \
             .
       - name: Clear


### PR DESCRIPTION
Hi,
I think we should use tagged containers. 
This change should tag every container with the git ref. If you create a Github relase you get a proper tag in hub.docker.com.
Regards, Kevin