### PR TITLE
feat: allow to specify static IP addresses 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -459,8 +459,9 @@ if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ]; then
 cat >> /etc/ppp/chap-secrets <<EOF
 "$addl_user" l2tpd "$addl_password" ${addl_ip:-*}
 EOF
+addl_ip_xauth=$([ -n "$addl_ip" ] && echo ":$addl_ip" || echo "")
 cat >> /etc/ipsec.d/passwd <<EOF
-$addl_user:$addl_password_enc:xauth-psk
+$addl_user:$addl_password_enc:xauth-psk${addl_ip_xauth}
 EOF
     count=$((count+1))
     addl_user=$(printf '%s' "$VPN_ADDL_USERS" | cut -s -d ' ' -f "$count")

--- a/run.sh
+++ b/run.sh
@@ -105,7 +105,7 @@ VPN_USER=$(noquotes "$VPN_USER")
 VPN_PASSWORD=$(nospaces "$VPN_PASSWORD")
 VPN_PASSWORD=$(noquotes "$VPN_PASSWORD")
 
-if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ] && [ -n "$VPN_ADDL_IP_ADDRS" ]; then
+if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ]; then
   VPN_ADDL_USERS=$(nospaces "$VPN_ADDL_USERS")
   VPN_ADDL_USERS=$(noquotes "$VPN_ADDL_USERS")
   VPN_ADDL_USERS=$(onespace "$VPN_ADDL_USERS")
@@ -114,14 +114,16 @@ if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ] && [ -n "$VPN_ADDL_I
   VPN_ADDL_PASSWORDS=$(noquotes "$VPN_ADDL_PASSWORDS")
   VPN_ADDL_PASSWORDS=$(onespace "$VPN_ADDL_PASSWORDS")
   VPN_ADDL_PASSWORDS=$(noquotes2 "$VPN_ADDL_PASSWORDS")
-  VPN_ADDL_IP_ADDRS=$(nospaces "$VPN_ADDL_IP_ADDRS")
-  VPN_ADDL_IP_ADDRS=$(noquotes "$VPN_ADDL_IP_ADDRS")
-  VPN_ADDL_IP_ADDRS=$(onespace "$VPN_ADDL_IP_ADDRS")
-  VPN_ADDL_IP_ADDRS=$(noquotes2 "$VPN_ADDL_IP_ADDRS")
 else
   VPN_ADDL_USERS=""
   VPN_ADDL_PASSWORDS=""
-  VPN_ADDL_IP_ADDRS=""
+fi
+
+if [ -n "$VPN_ADDL_IP_ADDRS" ]; then
+    VPN_ADDL_IP_ADDRS=$(nospaces "$VPN_ADDL_IP_ADDRS")
+    VPN_ADDL_IP_ADDRS=$(noquotes "$VPN_ADDL_IP_ADDRS")
+    VPN_ADDL_IP_ADDRS=$(onespace "$VPN_ADDL_IP_ADDRS")
+    VPN_ADDL_IP_ADDRS=$(noquotes2 "$VPN_ADDL_IP_ADDRS")
 fi
 
 if [ -n "$VPN_DNS_SRV1" ]; then

--- a/run.sh
+++ b/run.sh
@@ -105,7 +105,7 @@ VPN_USER=$(noquotes "$VPN_USER")
 VPN_PASSWORD=$(nospaces "$VPN_PASSWORD")
 VPN_PASSWORD=$(noquotes "$VPN_PASSWORD")
 
-if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ]; then
+if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ] && [ -n "$VPN_ADDL_IP_ADDRS" ]; then
   VPN_ADDL_USERS=$(nospaces "$VPN_ADDL_USERS")
   VPN_ADDL_USERS=$(noquotes "$VPN_ADDL_USERS")
   VPN_ADDL_USERS=$(onespace "$VPN_ADDL_USERS")
@@ -114,9 +114,14 @@ if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ]; then
   VPN_ADDL_PASSWORDS=$(noquotes "$VPN_ADDL_PASSWORDS")
   VPN_ADDL_PASSWORDS=$(onespace "$VPN_ADDL_PASSWORDS")
   VPN_ADDL_PASSWORDS=$(noquotes2 "$VPN_ADDL_PASSWORDS")
+  VPN_ADDL_IP_ADDRS=$(nospaces "$VPN_ADDL_IP_ADDRS")
+  VPN_ADDL_IP_ADDRS=$(noquotes "$VPN_ADDL_IP_ADDRS")
+  VPN_ADDL_IP_ADDRS=$(onespace "$VPN_ADDL_IP_ADDRS")
+  VPN_ADDL_IP_ADDRS=$(noquotes2 "$VPN_ADDL_IP_ADDRS")
 else
   VPN_ADDL_USERS=""
   VPN_ADDL_PASSWORDS=""
+  VPN_ADDL_IP_ADDRS=""
 fi
 
 if [ -n "$VPN_DNS_SRV1" ]; then
@@ -448,10 +453,11 @@ if [ -n "$VPN_ADDL_USERS" ] && [ -n "$VPN_ADDL_PASSWORDS" ]; then
   count=1
   addl_user=$(printf '%s' "$VPN_ADDL_USERS" | cut -d ' ' -f 1)
   addl_password=$(printf '%s' "$VPN_ADDL_PASSWORDS" | cut -d ' ' -f 1)
+  addl_ip=$(printf '%s' "$VPN_ADDL_IP_ADDRS" | cut -d ' ' -f 1)
   while [ -n "$addl_user" ] && [ -n "$addl_password" ]; do
     addl_password_enc=$(openssl passwd -1 "$addl_password")
 cat >> /etc/ppp/chap-secrets <<EOF
-"$addl_user" l2tpd "$addl_password" *
+"$addl_user" l2tpd "$addl_password" ${addl_ip:-*}
 EOF
 cat >> /etc/ipsec.d/passwd <<EOF
 $addl_user:$addl_password_enc:xauth-psk
@@ -459,6 +465,7 @@ EOF
     count=$((count+1))
     addl_user=$(printf '%s' "$VPN_ADDL_USERS" | cut -s -d ' ' -f "$count")
     addl_password=$(printf '%s' "$VPN_ADDL_PASSWORDS" | cut -s -d ' ' -f "$count")
+    addl_ip=$(printf '%s' "$VPN_ADDL_IP_ADDRS" | cut -s -d ' ' -f "$count")
   done
 fi
 


### PR DESCRIPTION
This PR introduces optional static IP addresses that work both in l2tp and ipsec-xauth. 

This feature request has been brought up many times: https://github.com/hwdsl2/docker-ipsec-vpn-server/issues/32, https://github.com/hwdsl2/docker-ipsec-vpn-server/pull/222 https://github.com/hwdsl2/docker-ipsec-vpn-server/issues/159 https://github.com/hwdsl2/setup-ipsec-vpn/issues/508

This feature is very much needed as one cannot easily build own Dockerfile based on this image because all of the configurations are done in `run.sh` script that is being run on CMD. Therefore, in the child Dockerfile, it is impossible to extend this configuration script - one has to copy the whole repository which is a hassle (for instance keeping it up to date).

With this PR, the user can specify `VPN_ADDL_IP_ADDRS` in addition to `VPN_ADDL_USERS` and `VPN_ADDL_PASSWORDS`. It works the same, for example:

```
VPN_ADDL_USERS=adduser1 adduser2 adduser3
VPN_ADDL_PASSWORDS=test1 test2 test3
VPN_ADDL_IP_ADDRS=192.168.42.3 192.168.42.4
```

`adduser1` will be assigned 192.168.42.3, `adduser2` is assigned 192.168.42.4 and `adduser3` is assigned a dynamic IP address from the pool.  Note, that the users with dynamic IP addresses should be stated at the end of the list (this should be stated in the docs). 

Please let me know what do you think if you like it I can:

1) possibly add the same feature with IKEv2
2) add `VPN_ADDL_IP_ADDRS` parameter validation  
3) update the documentation to cover this and explain the limitations (such that a user by default could specify 42.2-42.9 address or adjust VPN_L2TP_POOL accordingly)