### PR TITLE
make vpn_env file configurable

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -72,7 +72,7 @@ NET_IFACE=$(route 2>/dev/null | grep -m 1 '^default' | grep -o '[^ ]*$')
 [ -z "$NET_IFACE" ] && NET_IFACE=eth0
 
 mkdir -p /opt/src
-vpn_env="/opt/src/vpn.env"
+vpn_env=${VPN_ENVFILE:-"/opt/src/vpn.env"}
 vpn_gen_env="/etc/ipsec.d/vpn-gen.env"
 if [ -z "$VPN_IPSEC_PSK" ] && [ -z "$VPN_USER" ] && [ -z "$VPN_PASSWORD" ]; then
   if [ -f "$vpn_env" ]; then


### PR DESCRIPTION
This change will allow to specify a different location where to load the environment variable file.
You will be able to use `VPN_ENVFILE` to specify the file location.
As default the original path will be used.

I would appreciate the change because `--env-file ./vpn.env` is not possible for my usecase in Kubernetes.

If you want me to add some documentation I can add them as well.
But for now I will not add any as it is a minor change.