### PR TITLE
revert: remove explicit volume name from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 volumes:
   ikev2-vpn-data:
-    name: ikev2-vpn-data
 
 services:
   vpn:


### PR DESCRIPTION
BREAKING CHANGE: This reverts commit 62bfea8be13a889814fb1d41631ea5d43d7cda7c, which introduced a named volume. The volume name is unnecessary as Docker will auto-generate a name based on the project and volume key.

Pls see [my comment](https://github.com/hwdsl2/docker-ipsec-vpn-server/commit/62bfea8be13a889814fb1d41631ea5d43d7cda7c#commitcomment-187608133) for details.