### PR TITLE
Update Libreswan to 5.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM alpine:3.23
 
-ENV SWAN_VER=5.3.1
+ENV SWAN_VER=5.3.2
 WORKDIR /opt/src
 
 RUN set -x \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -9,7 +9,7 @@
 
 FROM debian:bookworm-slim
 
-ENV SWAN_VER=5.3.1
+ENV SWAN_VER=5.3.2
 WORKDIR /opt/src
 
 RUN apt-get -yqq update \

--- a/README-ru.md
+++ b/README-ru.md
@@ -91,7 +91,7 @@ docker image tag quay.io/hwdsl2/ipsec-vpn-server hwdsl2/ipsec-vpn-server
 | Сжатый размер     | ~ 19 MB                   | ~ 62 MB                        |
 | Базовый образ     | Alpine Linux 3.23         | Debian Linux 12                |
 | Платформы         | amd64, arm64, arm/v7      | amd64, arm64, arm/v7           |
-| Версия Libreswan  | 5.3.1                     | 5.3.1                          |
+| Версия Libreswan  | 5.3.2                     | 5.3.2                          |
 | IPsec/L2TP        | ✅                         | ✅                              |
 | Cisco IPsec       | ✅                         | ✅                              |
 | IKEv2             | ✅                         | ✅                              |

--- a/README-zh-Hant.md
+++ b/README-zh-Hant.md
@@ -91,7 +91,7 @@ docker image tag quay.io/hwdsl2/ipsec-vpn-server hwdsl2/ipsec-vpn-server
 | 壓縮後大小        | ~ 19 MB                  | ~ 62 MB                        |
 | 基礎映像          | Alpine Linux 3.23        | Debian Linux 12                |
 | 系統架構          | amd64, arm64, arm/v7     | amd64, arm64, arm/v7           |
-| Libreswan 版本   | 5.3.1                    | 5.3.1                          |
+| Libreswan 版本   | 5.3.2                    | 5.3.2                          |
 | IPsec/L2TP      | ✅                       | ✅                              |
 | Cisco IPsec     | ✅                       | ✅                              |
 | IKEv2           | ✅                       | ✅                              |

--- a/README-zh.md
+++ b/README-zh.md
@@ -91,7 +91,7 @@ docker image tag quay.io/hwdsl2/ipsec-vpn-server hwdsl2/ipsec-vpn-server
 | 压缩后大小        | ~ 19 MB                  | ~ 62 MB                        |
 | 基础镜像          | Alpine Linux 3.23        | Debian Linux 12                |
 | 系统架构          | amd64, arm64, arm/v7     | amd64, arm64, arm/v7           |
-| Libreswan 版本   | 5.3.1                    | 5.3.1                          |
+| Libreswan 版本   | 5.3.2                    | 5.3.2                          |
 | IPsec/L2TP      | ✅                       | ✅                              |
 | Cisco IPsec     | ✅                       | ✅                              |
 | IKEv2           | ✅                       | ✅                              |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Two pre-built images are available. The default Alpine-based image is only ~19 M
 | Compressed size   | ~ 19 MB                  | ~ 62 MB                        |
 | Base image        | Alpine Linux 3.23        | Debian Linux 12                |
 | Platforms         | amd64, arm64, arm/v7     | amd64, arm64, arm/v7           |
-| Libreswan version | 5.3.1                    | 5.3.1                          |
+| Libreswan version | 5.3.2                    | 5.3.2                          |
 | IPsec/L2TP        | ✅                       | ✅                              |
 | Cisco IPsec       | ✅                       | ✅                              |
 | IKEv2             | ✅                       | ✅                              |


### PR DESCRIPTION
### Motivation

- Update the Libreswan version used by the Alpine- and Debian-based Docker images to pick up the latest 5.3.2 release.
- Ensure the README files reflect the new Libreswan version for all supported locales.

### Description

- Bumped `SWAN_VER` from `5.3.1` to `5.3.2` in `Dockerfile` and `Dockerfile.debian` so image builds download Libreswan v5.3.2.
- Updated Libreswan version references in `README.md`, `README-ru.md`, `README-zh.md`, and `README-zh-Hant.md` to show `5.3.2`.
- No other functional changes to build steps or runtime configuration were introduced.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63919d18d483249b214a390a10b339)